### PR TITLE
Run CCD importer as a part of security scan environment startup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ timestamps {
           stage('Start & setup environment') {
             sh 'mkdir -p output'
             sh 'mkdir -p reports'
-            sh "docker-compose up -d zap-proxy remote-webdriver citizen-frontend legal-frontend"
+            sh "docker-compose up -d zap-proxy remote-webdriver citizen-frontend legal-frontend ccd-importer"
             sh "./bin/set-scanning-exclusions.sh ${execParams}"
           }
 


### PR DESCRIPTION
### Change description ###

CCD definitions import was not added after enabling CCD in Docker environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
